### PR TITLE
Making KeySpaces runtime child resources of Cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <version.wildfly>8.2.0.Final</version.wildfly>
+        <version.wildfly>1.0.0.Beta3-SNAPSHOT</version.wildfly>
         <version.junit>4.11</version.junit>
         <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>1.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
@@ -151,17 +151,19 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-controller</artifactId>
                 <version>${version.wildfly}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-server</artifactId>
                 <version>${version.wildfly}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-subsystem-test</artifactId>
                 <type>pom</type>
                 <scope>test</scope>
@@ -171,13 +173,14 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
                 <version>${version.org.jboss.logging.jboss-logging}</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-annotations</artifactId>
                 <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                      projects that depend on this project.-->
+                projects that depend on this project.-->
                 <scope>provided</scope>
                 <optional>true</optional>
                 <version>${version.org.jboss.logging.jboss-logging-tools}</version>
@@ -186,7 +189,7 @@
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-processor</artifactId>
                 <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                      projects that depend on this project.-->
+                projects that depend on this project.-->
                 <scope>provided</scope>
                 <optional>true</optional>
                 <version>${version.org.jboss.logging.jboss-logging-tools}</version>
@@ -209,6 +212,36 @@
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.addthis.metrics</groupId>
+                        <artifactId>reporter-config</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.addthis.metrics</groupId>
+                <artifactId>reporter-config3</artifactId>
+                <version>3.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
+                <artifactId>concurrentlinkedhashmap-lru</artifactId>
+                <version>1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.13</version>
+            </dependency>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>2.1.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.codahale.metrics</groupId>
+                        <artifactId>metrics-core</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -223,25 +256,31 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
+            projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -249,7 +288,7 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
+            projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -270,20 +309,47 @@
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.yammer.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.googlecode.concurrentlinkedhashmap</groupId>
             <artifactId>concurrentlinkedhashmap-lru</artifactId>
-            <version>1.4</version>
         </dependency>
-
         <!-- not part of cassandra-all.jar -->
         <dependency>
-        	<groupId>org.yaml</groupId>
-        	<artifactId>snakeyaml</artifactId>
-        	<version>1.13</version>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/src/main/assembly/module-assembly.xml
+++ b/src/main/assembly/module-assembly.xml
@@ -80,10 +80,12 @@
         <dependencySet>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
+            <!--<outputFileNameMapping>${artifactId}.${extension}</outputFileNameMapping>-->
             <outputDirectory>modules/system/layers/base/org/wildfly/extension/cassandra/main</outputDirectory>
             <includes>
                 <include>org.apache.cassandra:cassandra-all</include>
                 <include>org.apache.cassandra:cassandra-thrift</include>
+                <include>com.datastax.cassandra:cassandra-driver-core</include>
 
                 <include>org.xerial.snappy:snappy-java</include>
                 <include>net.jpountz.lz4:lz4</include>
@@ -99,14 +101,12 @@
                 <include>com.googlecode.json-simple</include>
                 <include>com.boundary:high-scale-lib</include>
                 <include>org.mindrot:jbcrypt</include>
-                <include>com.yammer.metrics:metrics-core</include>
-                <include>com.addthis.metrics:reporter-config</include>
+                <include>io.dropwizard.metrics:metrics-core</include>
+                <include>com.addthis.metrics:reporter-config3</include>
                 <include>com.thinkaurelius.thrift</include>
                 <include>com.lmax:disruptor</include>
                 <include>net.sf.supercsv</include>
                 <include>org.apache.thrift</include>
-                <include>org.apache.httpcomponents:httpclient</include>
-                <include>org.apache.httpcomponents:httpcore</include>
 
                 <include>com.github.jbellis:jamm</include>
                 <include>net.java.dev.jna:jna</include>

--- a/src/main/java/org/wildfly/extension/cassandra/CassandraConnection.java
+++ b/src/main/java/org/wildfly/extension/cassandra/CassandraConnection.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+import java.io.Closeable;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Session;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class CassandraConnection implements Closeable {
+
+    private Cluster cluster;
+
+    public CassandraConnection(String node) {
+        this(node, 9042);
+    }
+
+    public CassandraConnection(String node, int port) {
+        connect(node, port);
+    }
+
+    private final void connect(String node, int port) {
+        cluster = Cluster.builder().addContactPoint(node).withPort(port).build();
+        Metadata metadata = cluster.getMetadata();
+        CassandraLogger.LOGGER.infof("Connected to cluster: %s\n", metadata.getClusterName());
+        for (Host host : metadata.getAllHosts()) {
+            CassandraLogger.LOGGER.infof("Datacenter: %s; Host: %s; Rack: %s\n", host.getDatacenter(), host.getAddress(), host.getRack());
+        }
+    }
+
+    public Session getSession () {
+        assert cluster != null;
+        return cluster.connect();
+    }
+
+    @Override
+    public void close() {
+        cluster.close();
+    }
+
+}

--- a/src/main/java/org/wildfly/extension/cassandra/CassandraModel.java
+++ b/src/main/java/org/wildfly/extension/cassandra/CassandraModel.java
@@ -14,7 +14,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.wildfly.extension.cassandra;
 
 /**
@@ -48,4 +47,5 @@ public class CassandraModel {
     public static final String REQUEST_SCHEDULER = "request-scheduler";
     public static final String SERVER_ENCRYPTION = "server-encryption-enabled";
     public static final String CLIENT_ENCRYPTION = "client-encryption-enabled";
+    public static final String KEYSPACE = "keyspace";
 }

--- a/src/main/java/org/wildfly/extension/cassandra/CassandraOperationStepHandler.java
+++ b/src/main/java/org/wildfly/extension/cassandra/CassandraOperationStepHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public abstract class CassandraOperationStepHandler implements OperationStepHandler {
+
+    public void executeQuery(OperationContext context, String connectionPoint, int port, String query) {
+        try ( CassandraConnection connection = new CassandraConnection(connectionPoint, port);) {
+            try (Session session = connection.getSession()) {
+                ResultSet rs = session.execute(query);
+                processResult(context, rs);
+            }
+        }
+    }
+
+    public abstract void processResult(OperationContext context, ResultSet rs);
+}

--- a/src/main/java/org/wildfly/extension/cassandra/CassandraService.java
+++ b/src/main/java/org/wildfly/extension/cassandra/CassandraService.java
@@ -14,48 +14,66 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package org.wildfly.extension.cassandra;
 
+import static java.io.File.separatorChar;
+
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 import org.apache.cassandra.config.Config;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.Schema;
 import org.apache.cassandra.service.CassandraDaemon;
 import org.jboss.as.controller.services.path.AbsolutePathService;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
 /**
- * The cassandra runtime service.
- * Delegates to an adapter {@link CassandraDaemon} that wraps the actual C* services.
+ * The cassandra runtime service. Delegates to an adapter {@link CassandraDaemon} that wraps the actual C* services.
  *
  * @author Heiko Braun
  */
-public class CassandraService implements Service<CassandraService> {
+public class CassandraService implements Service<CassandraDaemon> {
 
+    public static final String CASSANDRA_DATA_FILE_DIR = "cassandra/data";
+    public static final String CASSANDRA_SAVED_CACHES_DIR = "cassandra/saved_caches";
+    public static final String CASSANDRA_COMMIT_LOG_DIR = "cassandra/commitlog";
 
-    private static final String CASSANDRA_DATA_FILE_DIR = "cassandra/data";
-    private static final String CASSANDRA_SAVED_CACHES_DIR = "cassandra/saved_caches";
-    private static final String CASSANDRA_COMMIT_LOG_DIR = "cassandra/commitlog";
+    public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append("cassandra");
 
     private final String clusterName;
     private final Config serviceConfig;
 
     private CassandraDaemon cassandraDaemon;
-    private final InjectedValue<PathManager> pathManager = new InjectedValue<PathManager>();
+    private final InjectedValue<PathManager> pathManagerValue = new InjectedValue<PathManager>();
 
     public CassandraService(String clusterName, Config serviceConfig) {
         this.clusterName = clusterName;
         this.serviceConfig = serviceConfig;
     }
 
+    public ServiceName getServiceName() {
+        return BASE_SERVICE_NAME.append(clusterName);
+    }
+
     @Override
-    public CassandraService getValue() throws IllegalStateException, IllegalArgumentException {
-        return this;
+    public CassandraDaemon getValue() throws IllegalStateException, IllegalArgumentException {
+        return cassandraDaemon;
     }
 
     @Override
@@ -66,39 +84,68 @@ public class CassandraService implements Service<CassandraService> {
 
             // resolve the path location
             // includes the _clusterName_ suffix to avid conflicts when different configurations are started on the same base system
-            if(null==serviceConfig.data_file_directories)
-                serviceConfig.data_file_directories = new String[]{resolve(pathManager.getValue(), CASSANDRA_DATA_FILE_DIR, ServerEnvironment.SERVER_DATA_DIR)+"/"+clusterName};
+            PathManager pathManager = pathManagerValue.getValue();
+            if (null == serviceConfig.data_file_directories) {
+                serviceConfig.data_file_directories = new String[]{
+                    resolve(pathManager, CASSANDRA_DATA_FILE_DIR, ServerEnvironment.SERVER_DATA_DIR) + separatorChar + clusterName};
+            }
 
-            if(null==serviceConfig.saved_caches_directory)
-                serviceConfig.saved_caches_directory = resolve(pathManager.getValue(), CASSANDRA_SAVED_CACHES_DIR, ServerEnvironment.SERVER_DATA_DIR)+"/"+clusterName;
+            if (null == serviceConfig.saved_caches_directory) {
+                serviceConfig.saved_caches_directory = resolve(pathManager, CASSANDRA_SAVED_CACHES_DIR, ServerEnvironment.SERVER_DATA_DIR)
+                        + separatorChar + clusterName;
+            }
 
-            if(null==serviceConfig.commitlog_directory)
-                serviceConfig.commitlog_directory = resolve(pathManager.getValue(), CASSANDRA_COMMIT_LOG_DIR, ServerEnvironment.SERVER_DATA_DIR)+"/"+clusterName;
-
+            if (null == serviceConfig.commitlog_directory) {
+                serviceConfig.commitlog_directory = resolve(pathManager, CASSANDRA_COMMIT_LOG_DIR, ServerEnvironment.SERVER_DATA_DIR)
+                        + separatorChar + clusterName;
+            }
+            boolean needConfigReload = DMRConfigLoader.CASSANDRA_CONFIG != null;
             // static injection needed due to the way C* initialises it's ConfigLoader
             DMRConfigLoader.CASSANDRA_CONFIG = serviceConfig;
 
             System.setProperty("cassandra.config.loader", DMRConfigLoader.class.getName());
-
+            if(needConfigReload) {
+                reloadConfig();
+            }
             cassandraDaemon = new CassandraDaemon(true);
             cassandraDaemon.activate();
-
         } catch (Throwable e) {
             context.failed(new StartException(e));
         }
     }
 
+    private void reloadConfig() throws IllegalArgumentException, IllegalAccessException, SecurityException, NoSuchMethodException, InvocationTargetException {
+        Method applyConfig = DatabaseDescriptor.class.getDeclaredMethod("applyConfig", Config.class);
+        applyConfig.setAccessible(true);
+        applyConfig.invoke(null, serviceConfig);
+//        DatabaseDescriptor.applyConfig(serviceConfig); we need to change this in C* code
+    }
+
     @Override
     public void stop(StopContext context) {
-        if(cassandraDaemon!=null)
-        {
+        if (cassandraDaemon != null) {
             CassandraLogger.LOGGER.infof("Stopping cassandra service '%s'.", clusterName);
+            MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            try {
+                Set<ObjectInstance> result = mbs.queryMBeans(new ObjectName("org.apache.cassandra.*:*"), null);
+                for(ObjectInstance cassandraMBean : result) {
+                    try {
+                        mbs.unregisterMBean(cassandraMBean.getObjectName());
+                    } catch (InstanceNotFoundException | MBeanRegistrationException ex) {
+                        //Who cares to unregister if it's not there.
+                    }
+                }
+            } catch (MalformedObjectNameException ex) {
+                CassandraLogger.LOGGER.warnf(ex, "Stopping cassandra service '%s', we have some error.", clusterName);
+            }
             cassandraDaemon.deactivate();
+            Schema.instance.clear();
+            cassandraDaemon = null;
         }
     }
 
-    public Injector<PathManager> getPathManagerInjector(){
-        return pathManager;
+    public Injector<PathManager> getPathManagerInjector() {
+        return pathManagerValue;
     }
 
     private String resolve(PathManager pathManager, String path, String relativeToPath) {

--- a/src/main/java/org/wildfly/extension/cassandra/ClusterResource.java
+++ b/src/main/java/org/wildfly/extension/cassandra/ClusterResource.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+import static org.wildfly.extension.cassandra.CassandraModel.KEYSPACE;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ControlledProcessStateService;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.DelegatingResource;
+import org.jboss.as.controller.registry.PlaceholderResource;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+/**
+ * Custom resource to be able to display keyspaces.
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class ClusterResource extends DelegatingResource {
+
+    private String connectionPoint;
+    private int port = ClusterDefinition.DEFAULT_NATIVE_PORT;
+    private ControlledProcessStateService processState;
+
+    private ClusterResource(Resource delegate, ControlledProcessStateService processState, String connectionPoint, int port) {
+        super(delegate);
+        this.connectionPoint = connectionPoint;
+        this.processState = processState;
+        this.port = port;
+    }
+
+    public ClusterResource() {
+        this((Resource.Factory.create(false)), null, "", ClusterDefinition.DEFAULT_NATIVE_PORT);
+    }
+
+    public void setConnectionPoint(String connectionPoint) {
+        this.connectionPoint = connectionPoint;
+    }
+
+    public String getConnectionPoint() {
+        return connectionPoint;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setProcessState(ControlledProcessStateService processState) {
+        this.processState = processState;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public Set<String> getChildrenNames(String childType) {
+        if (KEYSPACE.equals(childType)) {
+            return listKeyspaces().keySet();
+        }
+        return super.getChildrenNames(childType);
+    }
+
+    @Override
+    public Resource requireChild(PathElement element) {
+        if (KEYSPACE.equals(element.getKey())) {
+            return listKeyspaces().get(element.getValue());
+        }
+        return super.requireChild(element);
+    }
+
+    @Override
+    public boolean hasChildren(String childType) {
+        if (KEYSPACE.equals(childType)) {
+            return !listKeyspaces().isEmpty();
+        }
+        return super.hasChildren(childType);
+    }
+
+    @Override
+    public boolean hasChild(PathElement element) {
+        if (KEYSPACE.equals(element.getKey())) {
+            return listKeyspaces().containsKey(element.getValue());
+        }
+        return super.hasChild(element);
+    }
+
+    @Override
+    public Set<ResourceEntry> getChildren(String childType) {
+        if (KEYSPACE.equals(childType)) {
+            return new HashSet<>(listKeyspaces().values());
+        }
+        return super.getChildren(childType);
+    }
+
+    @Override
+    public Resource navigate(PathAddress address) {
+        if (address.size() > 0 && KEYSPACE.equals(address.getElement(0).getKey())) {
+            if (address.size() > 1) {
+                throw new NoSuchResourceException(address.getElement(1));
+            }
+            if (listKeyspaces().containsKey(address.getElement(0).getValue())) {
+                return Resource.Factory.create(true);
+            }
+            throw new NoSuchResourceException(address.getElement(0));
+        }
+        return super.navigate(address);
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        Set<String> types = super.getChildTypes();
+        types.add(KEYSPACE);
+        return types;
+    }
+
+    @Override
+    public Resource getChild(PathElement element) {
+        if (KEYSPACE.equals(element.getKey())) {
+            Map<String, ResourceEntry> keyspaces = listKeyspaces();
+            if (keyspaces.containsKey(element.getValue())) {
+                return keyspaces.get(element.getValue());
+            }
+            return PlaceholderResource.INSTANCE;
+        }
+        return super.getChild(element);
+    }
+
+    private Map<String, ResourceEntry> listKeyspaces() {
+        Map<String, ResourceEntry> result = new HashMap<>();
+        if (canAccessCluster()) {
+            try (CassandraConnection connection = new CassandraConnection(connectionPoint, port);) {
+                try (Session session = connection.getSession()) {
+                    ResultSet rs = session.execute("SELECT * FROM SYSTEM.SCHEMA_KEYSPACES;");
+                    for (Row row : rs) {
+                        String name = row.getString("keyspace_name");
+                        String strategy_class = row.getString("strategy_class");
+                        JSONObject options = (JSONObject) JSONValue.parse(row.getString("strategy_options"));
+                        int replication_factor = 1;
+                        if (options.containsKey("replication_factor")) {
+                            replication_factor = Integer.parseInt(options.get("replication_factor").toString());
+                        }
+                        result.put(name, new KeyspaceResourceEntry(name, strategy_class, replication_factor));
+                    }
+                }
+            } catch (NoHostAvailableException ex) {
+                CassandraLogger.LOGGER.debug("Surprise Surprise ", ex);
+            } catch (Exception ex) {
+                CassandraLogger.LOGGER.error("Surprise ", ex);
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("deprecation")
+    private boolean canAccessCluster() {
+        return processState != null && (processState.getCurrentState() == ControlledProcessState.State.RUNNING
+                || processState.getCurrentState() == ControlledProcessState.State.RELOAD_REQUIRED
+                || processState.getCurrentState() == ControlledProcessState.State.RESTART_REQUIRED);
+    }
+
+    public ControlledProcessStateService getProcessState() {
+        return processState;
+    }
+
+    @Override
+    public Resource clone() {
+        return new ClusterResource(super.clone(), processState, connectionPoint, port);
+    }
+
+    public static class KeyspaceResourceEntry implements ResourceEntry {
+
+        private final String name;
+        private final PathElement path;
+        private ModelNode model = new ModelNode();
+
+        public KeyspaceResourceEntry(String name, String strategy_class, int replication_factor) {
+            this.name = name;
+            this.path = PathElement.pathElement(KEYSPACE, name);
+            model.get(KeyspaceDefinition.CLASS.getName()).set(strategy_class);
+            model.get(KeyspaceDefinition.REPLICATION_FACTOR.getName()).set(replication_factor);
+            model.get(KeyspaceDefinition.NAME.getName()).set(name);
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public PathElement getPathElement() {
+            return path;
+        }
+
+        @Override
+        public ModelNode getModel() {
+            return model;
+        }
+
+        @Override
+        public void writeModel(ModelNode newModel) {
+            this.model = newModel;
+        }
+
+        @Override
+        public boolean isModelDefined() {
+            return this.model.isDefined();
+        }
+
+        @Override
+        public boolean hasChild(PathElement element) {
+            return false;
+        }
+
+        @Override
+        public Resource getChild(PathElement element) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource requireChild(PathElement element) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean hasChildren(String childType) {
+            return false;
+        }
+
+        @Override
+        public Resource navigate(PathAddress address) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Set<String> getChildTypes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getChildrenNames(String childType) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<ResourceEntry> getChildren(String childType) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void registerChild(PathElement address, Resource resource) {
+        }
+
+        @Override
+        public Resource removeChild(PathElement address) {
+            return null;
+        }
+
+        @Override
+        public boolean isRuntime() {
+            return true;
+        }
+
+        @Override
+        public boolean isProxy() {
+            return false;
+        }
+
+        @Override
+        public Resource clone() {
+            return new KeyspaceResourceEntry(name, model.get(KeyspaceDefinition.CLASS.getName()).asString(),
+                    model.get(KeyspaceDefinition.REPLICATION_FACTOR.getName()).asInt());
+        }
+
+    }
+}

--- a/src/main/java/org/wildfly/extension/cassandra/ClusterWriteAttributeHandler.java
+++ b/src/main/java/org/wildfly/extension/cassandra/ClusterWriteAttributeHandler.java
@@ -22,12 +22,10 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
-import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
-import java.util.ArrayList;
 
 /**
  * @author Heiko Braun
@@ -40,17 +38,12 @@ public class ClusterWriteAttributeHandler extends RestartParentWriteAttributeHan
     }
 
     @Override
-    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-        ClusterAdd.installRuntimeServices(context, parentAddress, parentModel, verificationHandler, new ArrayList<ServiceController<?>>());
-    }
-
-    @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
-        return ClusterAdd.SERVICE_NAME.append(parentAddress.getLastElement().getValue());
+        return CassandraService.BASE_SERVICE_NAME.append(Util.getNameFromAddress(parentAddress));
     }
 
     @Override
-    protected void removeServices(OperationContext context, ServiceName parentService, ModelNode parentModel) throws OperationFailedException {
-        super.removeServices(context, parentService, parentModel);
+    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
+        ClusterAdd.installRuntimeServices(context, parentAddress, parentModel);
     }
 }

--- a/src/main/java/org/wildfly/extension/cassandra/DMRConfigLoader.java
+++ b/src/main/java/org/wildfly/extension/cassandra/DMRConfigLoader.java
@@ -33,8 +33,9 @@ public class DMRConfigLoader implements ConfigurationLoader {
 
     @Override
     public Config loadConfig() throws ConfigurationException {
-        if(null==CASSANDRA_CONFIG)
+        if(null==CASSANDRA_CONFIG) {
             throw new IllegalStateException("Cassandra config not initialized");
+        }
 
         return CASSANDRA_CONFIG;
     }

--- a/src/main/java/org/wildfly/extension/cassandra/KeyspaceAddHandler.java
+++ b/src/main/java/org/wildfly/extension/cassandra/KeyspaceAddHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+import static org.wildfly.extension.cassandra.ClusterDefinition.LISTEN_ADDRESS;
+import static org.wildfly.extension.cassandra.ClusterDefinition.NATIVE_TRANSPORT_PORT;
+import static org.wildfly.extension.cassandra.KeyspaceDefinition.CLASS;
+import static org.wildfly.extension.cassandra.KeyspaceDefinition.REPLICATION_FACTOR;
+
+import com.datastax.driver.core.ResultSet;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class KeyspaceAddHandler extends CassandraOperationStepHandler {
+
+    public static final KeyspaceAddHandler INSTANCE = new KeyspaceAddHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        ModelNode model = new ModelNode();
+        String keySpaceName = Util.getNameFromAddress(context.getCurrentAddress());
+        KeyspaceDefinition.REPLICATION_FACTOR.validateAndSet(operation, model);
+        KeyspaceDefinition.CLASS.validateAndSet(operation, model);
+        Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
+        resource.writeModel(model);
+        ClusterResource cluster = (ClusterResource)context.readResourceFromRoot(context.getCurrentAddress().getParent());
+        ModelNode clusterNode = cluster.getModel();
+        String connectionPoint = LISTEN_ADDRESS.resolveModelAttribute(context, clusterNode).asString();
+        int port = NATIVE_TRANSPORT_PORT.resolveModelAttribute(context, clusterNode).asInt();
+        if(cluster.getProcessState().getCurrentState() == ControlledProcessState.State.RELOAD_REQUIRED) {
+            connectionPoint = cluster.getConnectionPoint();
+            port = cluster.getPort();
+        }
+        executeQuery(context, connectionPoint, port,
+                String.format("CREATE KEYSPACE \"%1s\" WITH REPLICATION = {'class':'%2s', 'replication_factor': %3d}",
+                    keySpaceName, CLASS.resolveModelAttribute(context, model).asString(),
+                    REPLICATION_FACTOR.resolveModelAttribute(context, model).asInt(1)));
+    }
+
+    @Override
+    public void processResult(OperationContext context, ResultSet rs) {
+    }
+}

--- a/src/main/java/org/wildfly/extension/cassandra/KeyspaceDefinition.java
+++ b/src/main/java/org/wildfly/extension/cassandra/KeyspaceDefinition.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+
+
+import static org.wildfly.extension.cassandra.CassandraModel.KEYSPACE;
+
+import java.util.Arrays;
+import java.util.Collection;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class KeyspaceDefinition extends PersistentResourceDefinition {
+
+    static final AttributeDefinition CLASS = SimpleAttributeDefinitionBuilder.create("class", ModelType.STRING)
+                    .setAllowNull(true)
+                    .setAllowExpression(false)
+                    .setMaxSize(20)
+                    .setDefaultValue(new ModelNode("SimpleStrategy")).build();
+
+    static final AttributeDefinition REPLICATION_FACTOR = SimpleAttributeDefinitionBuilder.create("replication_factor", ModelType.INT)
+                    .setAllowNull(true)
+                    .setAllowExpression(false)
+                    .setStorageRuntime()
+                    .setDefaultValue(new ModelNode(1)).build();
+
+    static final AttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING)
+                    .setAllowNull(false)
+                    .setStorageRuntime()
+                    .setAllowExpression(false)
+                    .setMaxSize(20).build();
+
+    static final AttributeDefinition[] ATTRIBUTES = {NAME, CLASS, REPLICATION_FACTOR};
+
+    public static final KeyspaceDefinition INSTANCE= new KeyspaceDefinition();
+
+    private KeyspaceDefinition() {
+        super(PathElement.pathElement(KEYSPACE),
+                CassandraExtension.getResourceDescriptionResolver(CassandraModel.CLUSTER, CassandraModel.KEYSPACE),
+                KeyspaceAddHandler.INSTANCE, KeyspaceRemoveHandler.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition attr : getAttributes()) {
+            resourceRegistration.registerReadOnlyAttribute(attr, null);
+        }
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+         return Arrays.asList(ATTRIBUTES);
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return true;
+    }
+}

--- a/src/main/java/org/wildfly/extension/cassandra/KeyspaceRemoveHandler.java
+++ b/src/main/java/org/wildfly/extension/cassandra/KeyspaceRemoveHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.extension.cassandra;
+
+import static org.wildfly.extension.cassandra.ClusterDefinition.LISTEN_ADDRESS;
+import static org.wildfly.extension.cassandra.ClusterDefinition.NATIVE_TRANSPORT_PORT;
+
+import com.datastax.driver.core.ResultSet;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+
+public class KeyspaceRemoveHandler extends CassandraOperationStepHandler {
+    public static final KeyspaceRemoveHandler INSTANCE = new KeyspaceRemoveHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        String keySpaceName = Util.getNameFromAddress(context.getCurrentAddress());
+        ClusterResource cluster = (ClusterResource)context.readResourceFromRoot(context.getCurrentAddress().getParent());
+        ModelNode clusterNode = cluster.getModel();
+        String connectionPoint = LISTEN_ADDRESS.resolveModelAttribute(context, clusterNode).asString();
+        int port = NATIVE_TRANSPORT_PORT.resolveModelAttribute(context, clusterNode).asInt();
+        if(cluster.getProcessState().getCurrentState() == ControlledProcessState.State.RELOAD_REQUIRED) {
+            connectionPoint = cluster.getConnectionPoint();
+            port = cluster.getPort();
+        }
+        executeQuery(context, connectionPoint, port, String.format("DROP KEYSPACE \"%1s\"", keySpaceName));
+        context.removeResource(PathAddress.EMPTY_ADDRESS);
+    }
+
+    @Override
+    public void processResult(OperationContext context, ResultSet rs) {
+    }
+
+}

--- a/src/main/java/org/wildfly/extension/cassandra/SubsystemParser.java
+++ b/src/main/java/org/wildfly/extension/cassandra/SubsystemParser.java
@@ -47,7 +47,7 @@ public class SubsystemParser implements XMLStreamConstants, XMLElementReader<Lis
         xmlDescription = builder(RootDefinition.INSTANCE)
                 .addChild(
                         builder(ClusterDefinition.INSTANCE)
-                                .addAttributes(ClusterDefinition.INSTANCE.getAttributes())
+                                .addAttributes(ClusterDefinition.ATTRIBUTES)
                 )               .setXmlElementName(CassandraModel.CLUSTER)
                 .build();
     }

--- a/src/main/resources/config/standalone-cassandra.xml
+++ b/src/main/resources/config/standalone-cassandra.xml
@@ -16,25 +16,18 @@
   ~  See the License for the specific language governing permissions and
   ~  limitations under the License.
   -->
-
-<server xmlns="urn:jboss:domain:2.1">
-
+<server xmlns="urn:jboss:domain:3.0">
     <extensions>
-        <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.jboss.as.logging"/>
-        <extension module="org.jboss.as.naming"/>
-        <extension module="org.jboss.as.remoting"/>
-        <extension module="org.jboss.as.security"/>
-        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.cassandra"/>
     </extensions>
-
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">
                 <authentication>
-                    <local default-user="$local" skip-group-loading="true"/>
+                    <local default-user="$local"/>
                     <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization map-groups-to-roles="false">
@@ -43,7 +36,7 @@
             </security-realm>
             <security-realm name="ApplicationRealm">
                 <authentication>
-                    <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                    <local default-user="$local" allowed-users="*"/>
                     <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
@@ -56,7 +49,7 @@
                 <json-formatter name="json-formatter"/>
             </formatters>
             <handlers>
-                <file-handler name="file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
+                <file-handler name="file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
             </handlers>
             <logger log-boot="true" log-read-only="false" enabled="false">
                 <handlers>
@@ -65,7 +58,7 @@
             </logger>
         </audit-log>
         <management-interfaces>
-            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true" allowed-origins="http://localhost http://docker">
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
@@ -79,9 +72,8 @@
             </role-mapping>
         </access-control>
     </management>
-
     <profile>
-        <subsystem xmlns="urn:jboss:domain:logging:2.0">
+        <subsystem xmlns="urn:jboss:domain:logging:3.0">
             <console-handler name="CONSOLE">
                 <level name="INFO"/>
                 <formatter>
@@ -122,69 +114,23 @@
                 </handlers>
             </root-logger>
             <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
             <formatter name="COLOR-PATTERN">
-                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
         </subsystem>
-
-        <subsystem xmlns="urn:wildfly:cassandra:1.0">
-            <cluster name="WildflyCluster"
-                     seed-provider-class-name="org.apache.cassandra.locator.SimpleSeedProvider"
-                     seed-provider-seeds="${jboss.bind.address:127.0.0.1}"
-                     listen-address="${jboss.bind.address:127.0.0.1}"
-                     broadcast-address="${jboss.bind.address:127.0.0.1}"
-                     start-rpc="true"
-                     start-native-transport="true"/>
-        </subsystem>
-
         <subsystem xmlns="urn:jboss:domain:jmx:1.3">
             <expose-resolved-model/>
             <expose-expression-model/>
             <remoting-connector/>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:request-controller:1.0"/>
 
-        <subsystem xmlns="urn:jboss:domain:security:1.2">
-            <security-domains>
-                <security-domain name="other" cache-type="default">
-                    <authentication>
-                        <login-module code="Remoting" flag="optional">
-                            <module-option name="password-stacking" value="useFirstPass"/>
-                        </login-module>
-                        <login-module code="RealmDirect" flag="required">
-                            <module-option name="password-stacking" value="useFirstPass"/>
-                        </login-module>
-                    </authentication>
-                </security-domain>
-                <security-domain name="jboss-web-policy" cache-type="default">
-                    <authorization>
-                        <policy-module code="Delegating" flag="required"/>
-                    </authorization>
-                </security-domain>
-                <security-domain name="jboss-ejb-policy" cache-type="default">
-                    <authorization>
-                        <policy-module code="Delegating" flag="required"/>
-                    </authorization>
-                </security-domain>
-            </security-domains>
-        </subsystem>
-
-        <subsystem xmlns="urn:jboss:domain:naming:2.0">
-            <remote-naming/>
-        </subsystem>
-
-        <subsystem xmlns="urn:jboss:domain:remoting:2.0">
-            <endpoint worker="default"/>
-            <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
-        </subsystem>
-
-        <subsystem xmlns="urn:jboss:domain:io:1.1">
-            <worker name="default"/>
-            <buffer-pool name="default"/>
+         <subsystem xmlns="urn:wildfly:cassandra:1.0">
+            <cluster name="WildflyCluster" />
         </subsystem>
     </profile>
-
     <interfaces>
         <interface name="management">
             <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
@@ -192,21 +138,12 @@
         <interface name="public">
             <inet-address value="${jboss.bind.address:127.0.0.1}"/>
         </interface>
-        <interface name="unsecure">
-            <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
-        </interface>
+<!--        <interface name="cassandra">
+            <nic name="eth0"/>  
+        </interface>-->
     </interfaces>
-
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
-        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
-        <socket-binding name="http" port="${jboss.http.port:8080}"/>
-        <socket-binding name="https" port="${jboss.https.port:8443}"/>
-        <socket-binding name="txn-recovery-environment" port="4712"/>
-        <socket-binding name="txn-status-manager" port="4713"/>
-        <outbound-socket-binding name="mail-smtp">
-            <remote-destination host="localhost" port="25"/>
-        </outbound-socket-binding>
     </socket-binding-group>
 </server>

--- a/src/main/resources/module/main/module.xml
+++ b/src/main/resources/module/main/module.xml
@@ -28,12 +28,13 @@
         <resource-root path="cassandra-all-3.0.0-SNAPSHOT.jar"/>
         <resource-root path="cassandra-thrift-3.0.0-SNAPSHOT.jar"/>
 
+        <!-- Datastax driver -->
+        <resource-root path="cassandra-driver-core-2.1.4.jar"/>
+
         <!-- cassandra dependencies -->
-        <resource-root path="httpclient-4.2.5.jar"/>
-        <resource-root path="httpcore-4.2.4.jar"/>
         <resource-root path="commons-codec-1.2.jar"/>
-        <resource-root path="snappy-java-1.0.5.jar"/>
-        <resource-root path="lz4-1.2.0.jar"/>
+        <resource-root path="snappy-java-1.0.5.2.jar"/>
+        <resource-root path="lz4-1.3.0.jar"/>
         <resource-root path="compress-lzf-0.8.4.jar"/>
         <resource-root path="guava-16.0.jar"/>
         <resource-root path="commons-lang3-3.1.jar"/>
@@ -46,13 +47,11 @@
         <resource-root path="json-simple-1.1.jar"/>
         <resource-root path="high-scale-lib-1.0.6.jar"/>
         <resource-root path="jbcrypt-0.3m.jar"/>
-        <resource-root path="metrics-core-2.2.0.jar"/>
-        <resource-root path="reporter-config-2.1.0.jar"/>
-        <resource-root path="hibernate-validator-4.3.0.Final.jar"/>
-        <resource-root path="validation-api-1.0.0.GA.jar"/>
+        <resource-root path="metrics-core-3.1.0.jar"/>
+        <resource-root path="reporter-config3-3.0.0.jar"/>
         <resource-root path="thrift-server-0.3.5.jar"/>
         <resource-root path="disruptor-3.0.1.jar"/>
-        <resource-root path="libthrift-0.9.1.jar"/>
+        <resource-root path="libthrift-0.9.2.jar"/>
         <resource-root path="super-csv-2.1.0.jar"/>
         <resource-root path="jamm-0.3.0.jar"/>
         <resource-root path="snakeyaml-1.13.jar"/>
@@ -60,8 +59,11 @@
         <resource-root path="sigar-1.6.4.jar"/>
         <resource-root path="stream-2.5.2.jar"/>
         <resource-root path="fastutil-6.5.7.jar"/>
+        <resource-root path="crc32ex-0.1.1.jar"/>
 
         <resource-root path="netty-all-4.0.23.Final.jar"/>
+
+        <resource-root path="jna-4.0.0.jar"/>
 
         <!-- the configuration overlays -->
         <resource-root path="conf"/>

--- a/src/main/resources/org/wildfly/extension/cassandra/LocalDescriptions.properties
+++ b/src/main/resources/org/wildfly/extension/cassandra/LocalDescriptions.properties
@@ -50,4 +50,12 @@ cassandra.cluster.commitlog-sync-period-in-ms=TODO
 cassandra.cluster.endpoint-snitch=Set this to a class that implements IEndpointSnitch
 cassandra.cluster.request-scheduler=Set this to a class that implements RequestScheduler
 cassandra.cluster.server-encryption-enabled=Enable or disable inter-node encryption
-cassandra.cluster.client-encryption-enabled=enable or disable client/server encryption.
+cassandra.cluster.client-encryption-enabled=Enable or disable client/server encryption.
+
+cassandra.cluster.keyspace=Keyspace
+cassandra.cluster.keyspace.class=Class of the replication strategy
+cassandra.cluster.keyspace.replication_factor=Replication factor of the replication strategy
+cassandra.cluster.keyspace.name=Name of the created keyspace
+cassandra.cluster.keyspace.add=Create a Keyspace
+cassandra.cluster.keyspace.remove=Drop a Keyspace
+cassandra.cluster.show-keyspaces=List the Keyspaces

--- a/src/main/resources/schema/cassandra.xsd
+++ b/src/main/resources/schema/cassandra.xsd
@@ -41,16 +41,16 @@
         <xs:attribute name="authorizer" use="optional" type="xs:string"/>
         <xs:attribute name="partioner" use="optional" type="xs:string"/>
 
-        <xs:attribute name="seed-provider-class-name" use="required" type="xs:string"/>
-        <xs:attribute name="seed-provider-seeds" use="required" type="xs:string"/>
+        <xs:attribute name="seed-provider-class-name" use="optional" type="xs:string"/>
+        <xs:attribute name="seed-provider-seeds" use="optional" type="xs:string"/>
 
-        <xs:attribute name="listen-address" use="required" type="xs:string"/>
-        <xs:attribute name="broadcast-address" use="required" type="xs:string"/>
+        <xs:attribute name="listen-address" use="optional" type="xs:string"/>
+        <xs:attribute name="broadcast-address" use="optional" type="xs:string"/>
 
-        <xs:attribute name="start-native-transport" use="required" type="xs:boolean"/>
+        <xs:attribute name="start-native-transport" use="optional" type="xs:boolean"/>
         <xs:attribute name="native-transport-port" use="optional" type="xs:long"/>
 
-        <xs:attribute name="start-rpc" use="required" type="xs:boolean"/>
+        <xs:attribute name="start-rpc" use="optional" type="xs:boolean"/>
         <xs:attribute name="rpc-port" use="optional" type="xs:long"/>
 
         <xs:attribute name="internode-authenticator" use="optional" type="xs:string"/>

--- a/src/main/resources/scripts/uninstall-cassandra.sh
+++ b/src/main/resources/scripts/uninstall-cassandra.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
 set -o xtrace
+WILDFLY_HOME=`dirname "$0"`
 
-rm -f bin/nodetool
-rm -rf modules/system/layers/base/org/wildfly/extension/cassandra/
-rm -f standalone/configuration/standalone-cassandra.xml
-rm -f domain/configuration/cassandra-domain.xml
-rm -f domain/configuration/cassandra-host.xml
+rm -f $WILDFLY_HOME/bin/nodetool
+rm -rf $WILDFLY_HOME/modules/system/layers/base/org/wildfly/extension/cassandra/
+rm -f $WILDFLY_HOME/standalone/configuration/standalone-cassandra.xml
+rm -f $WILDFLY_HOME/domain/configuration/cassandra-domain.xml
+rm -f $WILDFLY_HOME/domain/configuration/cassandra-host.xml
+rm -f $WILDFLY_HOME/uninstall-cassandra.sh

--- a/src/test/resources/test-subsystem.xml
+++ b/src/test/resources/test-subsystem.xml
@@ -16,12 +16,5 @@
   -->
 
 <subsystem xmlns="urn:wildfly:cassandra:1.0">
-    <cluster name="My Cluster"
-             seed-provider-class-name="org.apache.cassandra.locator.SimpleSeedProvider"
-             seed-provider-seeds="127.0.0.1"
-             listen-address="127.0.0.1"
-             broadcast-address="230.0.0.4"
-             start-rpc="true"
-             start-native-transport="true"
-             data-file-directories="data_dir"/>
+    <cluster name="My Cluster" />
 </subsystem>


### PR DESCRIPTION
Adding the operations to add/remove a keyspace
Better uninstall script
Making C\* stop clean so we now can reload the service.
Fixing the attibutes definition for cluster so that it can be restarted with the correct flags.
Making the default value an expression for cassandra configuration, to simplify config : <cluster name="WildflyCluster" />
Replace jboss.bind.address by jboss.bind.address.cassandra
